### PR TITLE
Separate two runs of 'pip install' to work around bug in EDTF library.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,7 @@ default[:tileserver][:revision][:tilequeue] = 'master'
 default[:tileserver][:revision][:mapbox_vector_tile] = 'master'
 default[:tileserver][:revision][:tileserver] = 'master'
 
-default[:tileserver][:pip_requirements] = %w(
+default[:tileserver][:pip_requirements_pypi] = %w(
   argparse==1.2.1
   boto==2.33.0
   hiredis==0.1.5
@@ -26,6 +26,7 @@ default[:tileserver][:pip_requirements] = %w(
   Pillow==2.6.1
   protobuf==2.6.0
   psycopg2==2.5.4
+  python-dateutil==2.4.2
   PyYAML==3.11
   redis==2.10.3
   Shapely==1.4.3
@@ -34,7 +35,7 @@ default[:tileserver][:pip_requirements] = %w(
   Werkzeug==0.9.6
   wsgiref==0.1.2
 )
-default[:tileserver][:pip_requirements] += [
+default[:tileserver][:pip_requirements_git] += [
   "git+https://github.com/mapzen/TileStache@#{node[:tileserver][:revision][:tilestache]}#egg=TileStache",
   "git+https://github.com/mapzen/tilequeue@#{node[:tileserver][:revision][:tilequeue]}#egg=tilequeue",
   "git+https://github.com/mapzen/mapbox-vector-tile@#{node[:tileserver][:revision][:mapbox_vector_tile]}#egg=mapbox-vector-tile",

--- a/recipes/deploy.rb
+++ b/recipes/deploy.rb
@@ -29,12 +29,14 @@ end
 # a separate file which is installed in a separate run due to a bug in
 # the setup.py of the EDTF library.
 [:pip_requirements_pypi, :pip_requirements_git].each do |req|
-  file "#{node[:tileserver][:cfg_path]}/#{req.to_s}.txt" do
+  req_file = "#{node[:tileserver][:cfg_path]}/#{req}.txt"
+
+  file req_file do
     content node[:tileserver][req].join("\n")
   end
 
   bash "install tileserver #{req.inspect}" do
-    code "pip install -U -r #{node[:tileserver][:cfg_path]}/#{req.to_s}.txt"
+    code "pip install -U -r #{req_file}"
     notifies :restart, 'runit_service[tileserver]', :delayed
   end
 end

--- a/recipes/deploy.rb
+++ b/recipes/deploy.rb
@@ -24,11 +24,17 @@ end
 # the code would have. Therefore we want to always run the pip install
 # on the requirements file to ensure that we get the latest packages
 # installed.
-file "#{node[:tileserver][:cfg_path]}/pip-requirements.txt" do
-  content node[:tileserver][:pip_requirements].join("\n")
-end
+#
+# note that we split the second set of git-based requirements off into
+# a separate file which is installed in a separate run due to a bug in
+# the setup.py of the EDTF library.
+[:pip_requirements_pypi, :pip_requirements_git].each do |req|
+  file "#{node[:tileserver][:cfg_path]}/#{req.to_s}.txt" do
+    content node[:tileserver][req].join("\n")
+  end
 
-bash 'install tileserver pip requirements' do
-  code "pip install -U -r #{node[:tileserver][:cfg_path]}/pip-requirements.txt"
-  notifies :restart, 'runit_service[tileserver]', :delayed
+  bash "install tileserver #{req.inspect}" do
+    code "pip install -U -r #{node[:tileserver][:cfg_path]}/#{req.to_s}.txt"
+    notifies :restart, 'runit_service[tileserver]', :delayed
+  end
 end


### PR DESCRIPTION
This is similar to a [work-around for tilequeue](https://github.com/mapzen/chef-tilequeue/pull/17), but this time for tileserver.

@heffergm could you review, please?
