### PR TITLE
Add configuration for the multiSQS queue.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -62,6 +62,7 @@ default[:tileserver][:postgresql][:password] = ''
 default[:tileserver][:redis][:enabled] = false
 default[:tileserver][:store][:enabled] = false
 default[:tileserver][:queue][:enabled] = false
+default[:tileserver][:queue][:zoom_queue_map] = nil
 
 default[:tileserver][:vector_datasource][:repository] = 'https://github.com/mapzen/vector-datasource.git'
 default[:tileserver][:vector_datasource][:path] = "#{node[:tileserver][:cfg_path]}/vector-datasource"

--- a/templates/default/tileserver.yaml.erb
+++ b/templates/default/tileserver.yaml.erb
@@ -62,6 +62,12 @@ redis:
 queue:
   type: <%= node[:tileserver][:queue][:type] %>
   name: <%= node[:tileserver][:queue][:name] %>
+  <%- if node[:tilequeue][:queue][:zoom_queue_map] -%>
+  zoom-queue-map:
+    <%- node[:tilequeue][:queue][:zoom_queue_map].each do |zoom_range, queue_name| -%>
+    <%= zoom_range %>: <%= queue_name %>
+    <%- end -%>
+  <%- end -%>
 <%- end -%>
 <%- if node[:tileserver][:health][:enabled] -%>
 health:


### PR DESCRIPTION
This was added in tilequeue's Chef, but missing here. This means that when tileserver renders a new tile and emits a job for tilequeue to follow up, it sends it to a queue that tilequeue isn't looking at.

@iandees could you review, please?